### PR TITLE
change directory of build on scripts for netlify

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
     "netlify": "^2.4.4"
   },
   "scripts": {
-    "build": "./market-orgs/src/index.js"
+    "build": "./market-org/src/index.js"
   }
 }


### PR DESCRIPTION
# Description

For Netlify deployment, the Package.json was referencing the wrong market-org url for the hyperlink, and as a result, netlify is not rendering our React app. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, but not tested (may need new tests)

# How Has This Been Tested?

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] There are no merge conflicts
